### PR TITLE
Issue 5: Expand the introduction

### DIFF
--- a/docs/analysis_plan.qmd
+++ b/docs/analysis_plan.qmd
@@ -7,11 +7,32 @@ bibliography: references.bib
 This document describes the analysis plan to perform a retrospective evaluation of the impact of incorporating wastewater data on the forecast performance of a semi-mechanistic renewal-based model, specifically the model available in the [@wwinference] R package.
 Forecasts of COVID-19 hospital admissions will be generated weekly and evaluated against the final observed hospital admissions data, across all age groups in Germany during the 2024-2025 respiratory virus season.
 
-# Aims
+# Introduction
 
-The goal of these analyses will be to assess:
+## Need
+Lots of investment in wastewater surveillance, hope is that it can be leveraged to improve situational awareness and potentially forecast performance.
+A number of studies have indicated that wastewater can be a leading indicator of changes in trends [cite Kao, many others].
+Wastewater surveillance for SARS-CoV-2 and Influenza A and B is being routinely collected and made publicly available in Germany, as well as in many other countries throughout the world [cite EU wastewater dashboard, South Africa data, NWSS, New Zealand data, etc.].
+However, it isn't clear how/whether this data is being used for real-time analysis, how existing modeling methods perform in different contexts, what the impact of incorporating wastewater is on model performance, and what other factors in the wastewater surveillance system may impact the model performance.
+
+## Gap
+
+1. Larger gap: Lack of evaluation of impact of wastewater on forecast performance: While a number of models have been developed to use wastewater to forecast hospital admissions, few have been evaluated to assess the impact of incorporating wastewater on forecast performance.
+2. Smaller gap: Unknown how a particular model, developed for one setting, generalises to different settings:
+The `wwinference` R package was developed to produce state-level forecasts of hospital admissions in the United States using state-level hospital admissions data and wastewater data from individual wastewater treatment plants.
+It is not known how this model generalises to a different context with a similar data structure.
+The data in Germany is similar to the U.S. in that they collect hospital admissions data at the state-level and measurements of the concentration of SARS-CoV-2 genomes in individual wastewater treatment plants within the state.
+3. Even smaller gap: Unknown what factors in the wastewater surveillance system impact forecast performance from this particular model.
+
+
+## Aims
+
+The goal of these analyses will be to assess, in the context of the 2024-2025 respiratory virus season in Germany using the `wwinference` model:
 1. How does incorporating wastewater impact the forecast performance of a semi-mechanistic renewal model?
 3. How do characteristics of the wastewater surveillance system impact the relative forecast performance of the wastewater-informed model?
+
+## What we do here
+In this paper, we retrospectively produced 28-day ahead forecasts of incident COVID-19 hospital admissions, with and without incorporating wastewater, for each state in Germany from October 2024 to May of 2025 using a semi-mechanistic renewal model, `wwinference`. Retrospective forecasts were produced in two ways: using only the data available as of the forecast date, which is subject to right-truncation and must incorporate a correction for reporting delays, and using the final observed hospital admissions data truncated to reflect the true lag in the data but exclude the right-truncation problem. Retrospective forecasts were evaluated against a rolling evaluation dataset using proper scoring metrics. We assess the value of incorporating wastewater by comparing the scores from both models overall, across horizons, locations, and forecast dates. To assess the impact of different characteristics of the wastewater surveillance system on forecast performance, we used a generative additive model with wastewater-informed forecast scores as an outcome while including covariate indicators which we hypothesized may have an impact on forecast performance. Based on these analyses, we assess the value of incorporating wastewater for this particular model and discuss areas for future development in wastewater-informed forecasting.
 
 # Methods
 


### PR DESCRIPTION
This PR addresses #5. It expands the aims section to include needs, gap, and what we do in this paper. 

I think the needs and gap could take a few different angles, and I am open to different ways of framing. I started with the first approach which focuses not on forecasting as the umbrella but on the nature of current investment in wastewater 

1.  Wastewater surveillance data is being produced and continued investment --> specific thing we do:
- ww data is being produced, lots of investment/potential
- very little evaluation of existing models and how they generalise
- limited investigation into drivers of relative forecast performance which we need to know to improve models/ww surveillance
- we apply a model produced for the US context to Germany to assess added value of incorporating wastewater and understand drivers of relative performance 

An alternative approach:
2. Forecasting --> specific thing we do:
- forecasting is difficult
- ww has potential to help
- very little evaluation of impact of incorporating ww into forecasts 
- very limited investigation into drivers of relative forecast performance which we need to know to improve models/ww surveillance
- unknown whether wastewater can improve forecasts in Germany
- we apply a specific model to Germany to assess added value of incorporating wastewater and understand drivers of relative performance 

