### PR TITLE
CI checks on all PRs not just PRs to main

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,8 +7,6 @@ on:
   schedule:
     - cron: '5 4 * * 1'
   pull_request:
-    branches:
-      - main
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -2,8 +2,6 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 name: lint-changed-files


### PR DESCRIPTION
We want R cmd check and linting checks to run on all PRs, not just those to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration workflows to run on pull requests from any branch, not just the main branch.
  - Applies to automated checks and linting; behaviour for manual runs remains unchanged.
  - No modifications to schedules or other workflow triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->