### PR TITLE
Hot fix: edits the trajectories to quantiles function 

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -85,20 +85,13 @@ trajectories_to_quantiles <- function(
       dplyr::across(tidyselect::all_of(c(timepoint_cols, id_cols)))
     )
 
-  missing_groups <- grouped_df |>
-    dplyr::summarize(
-      "any_missing" = anyNA(.data$value_col), # nolint
-      .groups = "drop"
-    ) |>
-    dplyr::filter(.data$any_missing) |>
-    dplyr::select(-"any_missing")
-
   quant_df <- grouped_df |>
-    dplyr::anti_join(missing_groups, by = colnames(missing_groups)) |>
+    filter(!is.na(value_col)) |>
     dplyr::reframe(
       !!quantile_value_name := stats::quantile(
         .data$value_col,
-        probs = !!quantiles
+        probs = !!quantiles,
+        nam.rm = TRUE
       ),
       !!quantile_level_name := !!quantiles
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -91,7 +91,7 @@ trajectories_to_quantiles <- function(
       !!quantile_value_name := stats::quantile(
         .data$value_col,
         probs = !!quantiles,
-        nam.rm = TRUE
+        na.rm = TRUE
       ),
       !!quantile_level_name := !!quantiles
     )


### PR DESCRIPTION
- The missingness handling was by group, so if any of the draws had NAs (which will happen if one chain fails) the enture group would be excluded, hence, no quantiles could be produced. This issue arose in Thorigen on 2025-03-03 in one of the VM runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data handling by enhancing the treatment of missing values in statistical calculations, resulting in more accurate and reliable quantile computations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->