### PR TITLE
Issue 109: add pairwise comparison

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.3.9016
+    rev: v0.4.3.9020
     hooks:
       - id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]

--- a/_targets.R
+++ b/_targets.R
@@ -88,6 +88,8 @@ get_metadata <- list(
 
 # Secondary outputs
 secondary_outputs <- list(
+  # pairwise comparisons of scores between models
+  pairwise_comparisons_targets,
   # GAM meta-model on scores ()
   run_gam_targets
   # compute coverage metrics (?)

--- a/targets/pairwise_comparisons_targets.R
+++ b/targets/pairwise_comparisons_targets.R
@@ -1,0 +1,63 @@
+pairwise_comparisons_targets <- list(
+  # Pairwise comparison tests using scoringutils
+  tar_target(
+    name = scores_for_comparison,
+    command = scores |>
+      mutate(model = glue::glue("{model}-{include_ww}")) |>
+      select(-include_ww, -hosp_data_real_time, -scale, -flag_missing_ww)
+  ),
+  tar_target(
+    name = pairwise_comparisons,
+    command = scores_for_comparison |>
+      get_pairwise_comparisons()
+  ),
+  tar_target(
+    name = pairwise_comparisons_filtered,
+    command = pairwise_comparisons |>
+      filter(compare_against == "wwinference-FALSE")
+  ),
+  tar_target(
+    name = pairwise_comparisons_loc,
+    command = scores_for_comparison |>
+      get_pairwise_comparisons(
+        by = "location"
+      )
+  ),
+  tar_target(
+    name = pairwise_comparisons_loc_filtered,
+    command = pairwise_comparisons_loc |>
+      filter(compare_against == "wwinference-FALSE")
+  ),
+  tar_target(
+    name = pairwise_comparisons_forecast_dates,
+    command = scores_for_comparison |>
+      get_pairwise_comparisons(
+        by = "forecast_date"
+      )
+  ),
+  tar_target(
+    name = pairwise_comparisons_fd_filtered,
+    command = pairwise_comparisons_forecast_dates |>
+      filter(compare_against == "wwinference-FALSE")
+  ),
+  tar_target(
+    name = plot_pwc,
+    command = plot_pairwise_comparisons(pairwise_comparisons,
+                                        type = "mean_scores_ratio"
+    )
+  ),
+  tar_target(
+    name = plot_pwc_locs,
+    command = plot_pairwise_comparisons(pairwise_comparisons_loc,
+                                        type = "mean_scores_ratio"
+    ) +
+      facet_wrap(~location)
+  ),
+  tar_target(
+    name = plot_pwc_fds,
+    command = plot_pairwise_comparisons(pairwise_comparisons_forecast_dates,
+                                        type = "mean_scores_ratio"
+    ) +
+      facet_wrap(~forecast_date)
+  )
+)

--- a/targets/pairwise_comparisons_targets.R
+++ b/targets/pairwise_comparisons_targets.R
@@ -14,7 +14,10 @@ pairwise_comparisons_targets <- list(
   tar_target(
     name = pairwise_comparisons_filtered,
     command = pairwise_comparisons |>
-      filter(compare_against == "wwinference-FALSE")
+      filter(
+        compare_against == "wwinference-FALSE",
+        model != compare_against
+      )
   ),
   tar_target(
     name = pairwise_comparisons_loc,
@@ -26,7 +29,10 @@ pairwise_comparisons_targets <- list(
   tar_target(
     name = pairwise_comparisons_loc_filtered,
     command = pairwise_comparisons_loc |>
-      filter(compare_against == "wwinference-FALSE")
+      filter(
+        compare_against == "wwinference-FALSE",
+        model != compare_against
+      )
   ),
   tar_target(
     name = pairwise_comparisons_forecast_dates,
@@ -38,25 +44,28 @@ pairwise_comparisons_targets <- list(
   tar_target(
     name = pairwise_comparisons_fd_filtered,
     command = pairwise_comparisons_forecast_dates |>
-      filter(compare_against == "wwinference-FALSE")
+      filter(
+        compare_against == "wwinference-FALSE",
+        model != compare_against
+      )
   ),
   tar_target(
     name = plot_pwc,
     command = plot_pairwise_comparisons(pairwise_comparisons,
-                                        type = "mean_scores_ratio"
+      type = "mean_scores_ratio"
     )
   ),
   tar_target(
     name = plot_pwc_locs,
     command = plot_pairwise_comparisons(pairwise_comparisons_loc,
-                                        type = "mean_scores_ratio"
+      type = "mean_scores_ratio"
     ) +
       facet_wrap(~location)
   ),
   tar_target(
     name = plot_pwc_fds,
     command = plot_pairwise_comparisons(pairwise_comparisons_forecast_dates,
-                                        type = "mean_scores_ratio"
+      type = "mean_scores_ratio"
     ) +
       facet_wrap(~forecast_date)
   )

--- a/targets/run_gam_targets.R
+++ b/targets/run_gam_targets.R
@@ -7,52 +7,6 @@ run_gam_targets <- list(
     name = scores,
     command = convert_to_su_object(scores_raw)
   ),
-  # Pairwise comparison tests using scoringutils
-  tar_target(
-    name = scores_for_comparison,
-    command = scores |>
-      mutate(model = glue::glue("{model}-{include_ww}")) |>
-      select(-include_ww, -hosp_data_real_time, -scale, -flag_missing_ww)
-  ),
-  tar_target(
-    name = pairwise_comparisons,
-    command = scores_for_comparison |>
-      get_pairwise_comparisons()
-  ),
-  tar_target(
-    name = pairwise_comparisons_loc,
-    command = scores_for_comparison |>
-      get_pairwise_comparisons(
-        by = "location"
-      )
-  ),
-  tar_target(
-    name = pairwise_comparisons_forecast_dates,
-    command = scores_for_comparison |>
-      get_pairwise_comparisons(
-        by = "forecast_date"
-      )
-  ),
-  tar_target(
-    name = plot_pwc,
-    command = plot_pairwise_comparisons(pairwise_comparisons,
-      type = "mean_scores_ratio"
-    )
-  ),
-  tar_target(
-    name = plot_pwc_locs,
-    command = plot_pairwise_comparisons(pairwise_comparisons_loc,
-      type = "mean_scores_ratio"
-    ) +
-      facet_wrap(~location)
-  ),
-  tar_target(
-    name = plot_pwc_fds,
-    command = plot_pairwise_comparisons(pairwise_comparisons_forecast_dates,
-      type = "mean_scores_ratio"
-    ) +
-      facet_wrap(~forecast_date)
-  ),
   tar_target(
     name = scores_to_model,
     command = prep_scores_to_model(

--- a/targets/run_gam_targets.R
+++ b/targets/run_gam_targets.R
@@ -7,6 +7,52 @@ run_gam_targets <- list(
     name = scores,
     command = convert_to_su_object(scores_raw)
   ),
+  # Pairwise comparison tests using scoringutils
+  tar_target(
+    name = scores_for_comparison,
+    command = scores |>
+      mutate(model = glue::glue("{model}-{include_ww}")) |>
+      select(-include_ww, -hosp_data_real_time, -scale, -flag_missing_ww)
+  ),
+  tar_target(
+    name = pairwise_comparisons,
+    command = scores_for_comparison |>
+      get_pairwise_comparisons()
+  ),
+  tar_target(
+    name = pairwise_comparisons_loc,
+    command = scores_for_comparison |>
+      get_pairwise_comparisons(
+        by = "location"
+      )
+  ),
+  tar_target(
+    name = pairwise_comparisons_forecast_dates,
+    command = scores_for_comparison |>
+      get_pairwise_comparisons(
+        by = "forecast_date"
+      )
+  ),
+  tar_target(
+    name = plot_pwc,
+    command = plot_pairwise_comparisons(pairwise_comparisons,
+      type = "mean_scores_ratio"
+    )
+  ),
+  tar_target(
+    name = plot_pwc_locs,
+    command = plot_pairwise_comparisons(pairwise_comparisons_loc,
+      type = "mean_scores_ratio"
+    ) +
+      facet_wrap(~location)
+  ),
+  tar_target(
+    name = plot_pwc_fds,
+    command = plot_pairwise_comparisons(pairwise_comparisons_forecast_dates,
+      type = "mean_scores_ratio"
+    ) +
+      facet_wrap(~forecast_date)
+  ),
   tar_target(
     name = scores_to_model,
     command = prep_scores_to_model(


### PR DESCRIPTION
This PR performs a pairwise comparison of each combination of the wastewater informed and hospital admissions only model and the baseline ARIMA model. 

It does so overall, by forecast date, and by location.

The results look to be that overall, the wastewater-informed model improvement has a p-value of 0.014 compare to the hospital admissions only model. 

```r
pairwise_comparisons_filtered
                  model   compare_against mean_scores_ratio       pval   adj_pval wis_relative_skill
                 <glue>            <char>             <num>      <num>      <num>              <num>
1: arima_baseline-FALSE wwinference-FALSE         1.1125605 0.00000000 0.00000000          1.0776349
2:    wwinference-FALSE wwinference-FALSE         1.0000000 1.00000000 1.00000000          0.9685039
3:     wwinference-TRUE wwinference-FALSE         0.9894009 0.01495061 0.01495061          0.9581357
```

This is useful context for framing as I think give us a justification for making a statement like including wastewater results in a  indicate meaningful improvement in forecast performance (as would a p value of 0 which indicates a meaningfully worse performance of the arima model)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced pairwise comparison analysis framework enabling systematic evaluation of model predictions.
- Added filtering capabilities for targeted model comparisons.
- Included location-based and forecast-date-based comparison analysis.
- Integrated visualisations to display pairwise comparison results and trends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->